### PR TITLE
npyio: optionally takes only part of data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+language: go
+os:
+  - linux
+
+env:
+ - TAGS="-tags travis"
+
+matrix:
+ fast_finish: true
+ allow_failures:
+   - go: master
+ include:
+   - go: 1.9.x
+     env:
+       - TAGS="-tags travis"
+   - go: 1.10.x
+     env:
+       - TAGS="-tags travis"
+       - COVERAGE="-cover"
+   - go: master
+     env:
+       - TAGS="-tags travis"
+
+sudo: false
+
+notifications:
+  email:
+    recipients:
+      - binet@cern.ch
+    on_success: always
+    on_failure: always
+
+script:
+ - go get -d -t -v ./...
+ - go install -v $TAGS ./...
+ - go run ./ci/run-tests.go -race $TAGS $COVERAGE
+
+after_success:
+ - bash <(curl -s https://codecov.io/bash)

--- a/AUTHORS
+++ b/AUTHORS
@@ -8,4 +8,5 @@
 
 # Please keep the list sorted.
 
+Renato Lui Geh <renatolg@ime.usp.br> <renatogeh@gmail.com>
 Sebastien Binet <binet@cern.ch> <seb.binet@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,11 @@
+# This is the official list of npyio authors for copyright purposes.
+# This file is distinct from the CONTRIBUTORS files.
+# See the latter for an explanation.
+
+# Names should be added to this file as
+#	Name or Organization <email address>
+# The email address is not required for organizations.
+
+# Please keep the list sorted.
+
+Sebastien Binet <binet@cern.ch> <seb.binet@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,18 @@
+# This is the official list of people who can contribute
+# (and typically have contributed) code to the npyio
+# repository.
+#
+# The AUTHORS file lists the copyright holders; this file
+# lists people.  For example, ACME Inc. employees would be listed here
+# but not in AUTHORS, because ACME Inc. would hold the copyright.
+#
+# When adding J Random Contributor's name to this file,
+# either J's name or J's organization's name should be
+# added to the AUTHORS file.
+#
+# Names should be added to this file like so:
+#     Name <email address>
+#
+# Please keep the list sorted.
+
+Sebastien Binet <binet@cern.ch> <seb.binet@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -15,4 +15,5 @@
 #
 # Please keep the list sorted.
 
+Renato Lui Geh <renatolg@ime.usp.br> <renatogeh@gmail.com>
 Sebastien Binet <binet@cern.ch> <seb.binet@gmail.com>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# npyio [![GoDoc](https://godoc.org/github.com/sbinet/npyio?status.svg)](https://godoc.org/github.com/sbinet/npyio)
+# npyio
+
+[![Build Status](https://travis-ci.org/sbinet/npyio.svg?branch=master)](https://travis-ci.org/sbinet/npyio)
+[![codecov](https://codecov.io/gh/sbinet/npyio/branch/master/graph/badge.svg)](https://codecov.io/gh/sbinet/npyio)
+[![Go Report Card](https://goreportcard.com/badge/github.com/sbinet/npyio)](https://goreportcard.com/report/github.com/sbinet/npyio)
+[![License](https://img.shields.io/badge/License-BSD--3-blue.svg)](https://github.com/sbinet/npyio/blob/master/LICENSE)
+[![GoDoc](https://godoc.org/github.com/sbinet/npyio?status.svg)](https://godoc.org/github.com/sbinet/npyio)
 
 `npyio` provides read/write access to [numpy data files](http://docs.scipy.org/doc/numpy/neps/npy-format.html).
 

--- a/ci/run-tests.go
+++ b/ci/run-tests.go
@@ -1,0 +1,94 @@
+// Copyright 2018 The npyio Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build ignore
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"flag"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func main() {
+	log.SetPrefix("ci: ")
+	log.SetFlags(0)
+
+	var (
+		race  = flag.Bool("race", false, "enable race detector")
+		cover = flag.Bool("cover", false, "enable code coverage")
+		tags  = flag.String("tags", "", "build tags")
+	)
+
+	flag.Parse()
+
+	out := new(bytes.Buffer)
+	cmd := exec.Command("go", "list", "./...")
+	cmd.Stdout = out
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+
+	err := cmd.Run()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	f, err := os.Create("coverage.txt")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer f.Close()
+
+	args := []string{"test"}
+
+	if *cover {
+		args = append(args, "-coverprofile=profile.out", "-covermode=atomic")
+	}
+	if *tags != "" {
+		args = append(args, "-tags="+*tags)
+	}
+	if *race {
+		args = append(args, "-race")
+	}
+	args = append(args, "")
+
+	scan := bufio.NewScanner(out)
+	for scan.Scan() {
+		pkg := scan.Text()
+		if strings.Contains(pkg, "vendor") {
+			continue
+		}
+		args[len(args)-1] = pkg
+		cmd := exec.Command("go", args...)
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		err := cmd.Run()
+		if err != nil {
+			log.Fatal(err)
+		}
+		if *cover {
+			profile, err := ioutil.ReadFile("profile.out")
+			if err != nil {
+				log.Fatal(err)
+			}
+			_, err = f.Write(profile)
+			if err != nil {
+				log.Fatal(err)
+			}
+			os.Remove("profile.out")
+		}
+	}
+
+	err = f.Close()
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/npyio_example_test.go
+++ b/npyio_example_test.go
@@ -96,6 +96,7 @@ func ExamplePartialRead() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer out.Close()
 
 	f := []float64{0, 1, 2, 3, 4, 5}
 	fmt.Printf("-- original data --\n")
@@ -104,7 +105,10 @@ func ExamplePartialRead() {
 	if err != nil {
 		log.Fatalf("error writing data: %v\n", err)
 	}
-	out.Close()
+	err = out.Close()
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	in, err := os.Open("data.npy")
 	if err != nil {

--- a/npyio_example_test.go
+++ b/npyio_example_test.go
@@ -135,9 +135,9 @@ func ExamplePartialRead() {
 
 	// Output:
 	// -- original data --
-	// data = 0 1 2 3 4 5
+	// data = [0 1 2 3 4 5]
 	// -- partial data read back --
-	// data = 0 1 2
+	// data = [0 1 2]
 	// -- rest of data read back --
-	// data = 3 4 5
+	// data = [3 4 5]
 }

--- a/npyio_example_test.go
+++ b/npyio_example_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"os"
 
 	"gonum.org/v1/gonum/mat"
 
@@ -88,4 +89,55 @@ func ExampleRead() {
 	// -- modified original data --
 	// data = ⎡6  1  2⎤
 	//        ⎣3  4  5⎦
+}
+
+func ExamplePartialRead() {
+	out, err := os.Create("data.npy")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	f := []float64{0, 1, 2, 3, 4, 5}
+	fmt.Printf("-- original data --\n")
+	fmt.Printf("data = %v\n", f)
+	err = npyio.Write(out, f)
+	if err != nil {
+		log.Fatalf("error writing data: %v\n", err)
+	}
+	out.Close()
+
+	in, err := os.Open("data.npy")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer in.Close()
+	r, err := npyio.NewReader(in)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	data := make([]float64, 3)
+	err = r.Read(&data)
+	if err != nil {
+		log.Fatalf("error reading data: %v\n", err)
+	}
+
+	fmt.Printf("-- partial data read back --\n")
+	fmt.Printf("data = %v\n", data)
+
+	err = r.Read(&data)
+	if err != nil {
+		log.Fatalf("error reading data: %v\n", err)
+	}
+
+	fmt.Printf("-- rest of data read back --\n")
+	fmt.Printf("data = %v\n", data)
+
+	// Output:
+	// -- original data --
+	// data = 0 1 2 3 4 5
+	// -- partial data read back --
+	// data = 0 1 2
+	// -- rest of data read back --
+	// data = 3 4 5
 }

--- a/reader.go
+++ b/reader.go
@@ -238,9 +238,10 @@ func (r *Reader) Read(ptr interface{}) error {
 		if dt.rt != boolType {
 			return ErrTypeMismatch
 		}
-		*vptr = make([]bool, nelems)
+		n := bufferSize(len(*vptr), nelems)
+		*vptr = make([]bool, n)
 		var buf [1]byte
-		for i := 0; i < nelems; i++ {
+		for i := 0; i < n; i++ {
 			_, err := r.r.Read(buf[:])
 			if err != nil && err != io.EOF {
 				r.err = err
@@ -272,9 +273,10 @@ func (r *Reader) Read(ptr interface{}) error {
 		if dt.rt != int8Type {
 			return ErrTypeMismatch
 		}
-		*vptr = make([]int8, nelems)
+		n := bufferSize(len(*vptr), nelems)
+		*vptr = make([]int8, n)
 		var buf [1]byte
-		for i := 0; i < nelems; i++ {
+		for i := 0; i < n; i++ {
 			_, err := r.r.Read(buf[:])
 			if err != nil && err != io.EOF {
 				r.err = err
@@ -301,9 +303,10 @@ func (r *Reader) Read(ptr interface{}) error {
 		if dt.rt != int16Type {
 			return ErrTypeMismatch
 		}
-		*vptr = make([]int16, nelems)
+		n := bufferSize(len(*vptr), nelems)
+		*vptr = make([]int16, n)
 		var buf [2]byte
-		for i := 0; i < nelems; i++ {
+		for i := 0; i < n; i++ {
 			_, err := r.r.Read(buf[:])
 			if err != nil && err != io.EOF {
 				r.err = err
@@ -330,9 +333,10 @@ func (r *Reader) Read(ptr interface{}) error {
 		if dt.rt != int32Type {
 			return ErrTypeMismatch
 		}
-		*vptr = make([]int32, nelems)
+		n := bufferSize(len(*vptr), nelems)
+		*vptr = make([]int32, n)
 		var buf [4]byte
-		for i := 0; i < nelems; i++ {
+		for i := 0; i < n; i++ {
 			_, err := r.r.Read(buf[:])
 			if err != nil && err != io.EOF {
 				r.err = err
@@ -359,9 +363,10 @@ func (r *Reader) Read(ptr interface{}) error {
 		if dt.rt != int64Type {
 			return ErrTypeMismatch
 		}
-		*vptr = make([]int64, nelems)
+		n := bufferSize(len(*vptr), nelems)
+		*vptr = make([]int64, n)
 		var buf [8]byte
-		for i := 0; i < nelems; i++ {
+		for i := 0; i < n; i++ {
 			_, err := r.r.Read(buf[:])
 			if err != nil && err != io.EOF {
 				r.err = err
@@ -389,8 +394,9 @@ func (r *Reader) Read(ptr interface{}) error {
 			return ErrTypeMismatch
 		}
 		var buf [1]byte
-		*vptr = make([]uint8, nelems)
-		for i := 0; i < nelems; i++ {
+		n := bufferSize(len(*vptr), nelems)
+		*vptr = make([]uint8, n)
+		for i := 0; i < n; i++ {
 			_, err := r.r.Read(buf[:])
 			if err != nil && err != io.EOF {
 				r.err = err
@@ -417,9 +423,10 @@ func (r *Reader) Read(ptr interface{}) error {
 		if dt.rt != uint16Type {
 			return ErrTypeMismatch
 		}
-		*vptr = make([]uint16, nelems)
+		n := bufferSize(len(*vptr), nelems)
+		*vptr = make([]uint16, n)
 		var buf [2]byte
-		for i := 0; i < nelems; i++ {
+		for i := 0; i < n; i++ {
 			_, err := r.r.Read(buf[:])
 			if err != nil && err != io.EOF {
 				r.err = err
@@ -446,9 +453,10 @@ func (r *Reader) Read(ptr interface{}) error {
 		if dt.rt != uint32Type {
 			return ErrTypeMismatch
 		}
-		*vptr = make([]uint32, nelems)
+		n := bufferSize(len(*vptr), nelems)
+		*vptr = make([]uint32, n)
 		var buf [4]byte
-		for i := 0; i < nelems; i++ {
+		for i := 0; i < n; i++ {
 			_, err := r.r.Read(buf[:])
 			if err != nil && err != io.EOF {
 				r.err = err
@@ -475,9 +483,10 @@ func (r *Reader) Read(ptr interface{}) error {
 		if dt.rt != uint64Type {
 			return ErrTypeMismatch
 		}
-		*vptr = make([]uint64, nelems)
+		n := bufferSize(len(*vptr), nelems)
+		*vptr = make([]uint64, n)
 		var buf [8]byte
-		for i := 0; i < nelems; i++ {
+		for i := 0; i < n; i++ {
 			_, err := r.r.Read(buf[:])
 			if err != nil && err != io.EOF {
 				r.err = err
@@ -504,9 +513,10 @@ func (r *Reader) Read(ptr interface{}) error {
 		if dt.rt != float32Type {
 			return ErrTypeMismatch
 		}
-		*vptr = make([]float32, nelems)
+		n := bufferSize(len(*vptr), nelems)
+		*vptr = make([]float32, n)
 		var buf [4]byte
-		for i := 0; i < nelems; i++ {
+		for i := 0; i < n; i++ {
 			_, err := r.r.Read(buf[:])
 			if err != nil && err != io.EOF {
 				r.err = err
@@ -533,9 +543,10 @@ func (r *Reader) Read(ptr interface{}) error {
 		if dt.rt != float64Type {
 			return ErrTypeMismatch
 		}
-		*vptr = make([]float64, nelems)
+		n := bufferSize(len(*vptr), nelems)
+		*vptr = make([]float64, n)
 		var buf [8]byte
-		for i := 0; i < nelems; i++ {
+		for i := 0; i < n; i++ {
 			_, err := r.r.Read(buf[:])
 			if err != nil && err != io.EOF {
 				r.err = err
@@ -564,9 +575,10 @@ func (r *Reader) Read(ptr interface{}) error {
 		if dt.rt != complex64Type {
 			return ErrTypeMismatch
 		}
-		*vptr = make([]complex64, nelems)
+		n := bufferSize(len(*vptr), nelems)
+		*vptr = make([]complex64, n)
 		var buf [8]byte
-		for i := 0; i < nelems; i++ {
+		for i := 0; i < n; i++ {
 			_, err := r.r.Read(buf[:])
 			if err != nil && err != io.EOF {
 				r.err = err
@@ -597,9 +609,10 @@ func (r *Reader) Read(ptr interface{}) error {
 		if dt.rt != complex128Type {
 			return ErrTypeMismatch
 		}
-		*vptr = make([]complex128, nelems)
+		n := bufferSize(len(*vptr), nelems)
+		*vptr = make([]complex128, n)
 		var buf [16]byte
-		for i := 0; i < nelems; i++ {
+		for i := 0; i < n; i++ {
 			_, err := r.r.Read(buf[:])
 			if err != nil && err != io.EOF {
 				r.err = err
@@ -804,4 +817,21 @@ func stringLen(dtype string) (int, error) {
 		return int(v), nil
 	}
 	return 0, fmt.Errorf("npyio: %q is not a string-like dtype", dtype)
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func bufferSize(l, m int) int {
+	var n int
+	if l != 0 {
+		n = min(l, m)
+	} else {
+		n = m
+	}
+	return n
 }

--- a/reader.go
+++ b/reader.go
@@ -238,8 +238,11 @@ func (r *Reader) Read(ptr interface{}) error {
 		if dt.rt != boolType {
 			return ErrTypeMismatch
 		}
-		n := bufferSize(len(*vptr), nelems)
-		*vptr = make([]bool, n)
+		n := min(len(*vptr), nelems)
+		if n == 0 {
+			n = nelems
+			*vptr = make([]bool, n)
+		}
 		var buf [1]byte
 		for i := 0; i < n; i++ {
 			_, err := r.r.Read(buf[:])
@@ -273,8 +276,11 @@ func (r *Reader) Read(ptr interface{}) error {
 		if dt.rt != int8Type {
 			return ErrTypeMismatch
 		}
-		n := bufferSize(len(*vptr), nelems)
-		*vptr = make([]int8, n)
+		n := min(len(*vptr), nelems)
+		if n == 0 {
+			n = nelems
+			*vptr = make([]int8, n)
+		}
 		var buf [1]byte
 		for i := 0; i < n; i++ {
 			_, err := r.r.Read(buf[:])
@@ -303,8 +309,11 @@ func (r *Reader) Read(ptr interface{}) error {
 		if dt.rt != int16Type {
 			return ErrTypeMismatch
 		}
-		n := bufferSize(len(*vptr), nelems)
-		*vptr = make([]int16, n)
+		n := min(len(*vptr), nelems)
+		if n == 0 {
+			n = nelems
+			*vptr = make([]int16, n)
+		}
 		var buf [2]byte
 		for i := 0; i < n; i++ {
 			_, err := r.r.Read(buf[:])
@@ -333,8 +342,11 @@ func (r *Reader) Read(ptr interface{}) error {
 		if dt.rt != int32Type {
 			return ErrTypeMismatch
 		}
-		n := bufferSize(len(*vptr), nelems)
-		*vptr = make([]int32, n)
+		n := min(len(*vptr), nelems)
+		if n == 0 {
+			n = nelems
+			*vptr = make([]int32, n)
+		}
 		var buf [4]byte
 		for i := 0; i < n; i++ {
 			_, err := r.r.Read(buf[:])
@@ -363,8 +375,11 @@ func (r *Reader) Read(ptr interface{}) error {
 		if dt.rt != int64Type {
 			return ErrTypeMismatch
 		}
-		n := bufferSize(len(*vptr), nelems)
-		*vptr = make([]int64, n)
+		n := min(len(*vptr), nelems)
+		if n == 0 {
+			n = nelems
+			*vptr = make([]int64, n)
+		}
 		var buf [8]byte
 		for i := 0; i < n; i++ {
 			_, err := r.r.Read(buf[:])
@@ -394,8 +409,11 @@ func (r *Reader) Read(ptr interface{}) error {
 			return ErrTypeMismatch
 		}
 		var buf [1]byte
-		n := bufferSize(len(*vptr), nelems)
-		*vptr = make([]uint8, n)
+		n := min(len(*vptr), nelems)
+		if n == 0 {
+			n = nelems
+			*vptr = make([]uint8, n)
+		}
 		for i := 0; i < n; i++ {
 			_, err := r.r.Read(buf[:])
 			if err != nil && err != io.EOF {
@@ -423,8 +441,11 @@ func (r *Reader) Read(ptr interface{}) error {
 		if dt.rt != uint16Type {
 			return ErrTypeMismatch
 		}
-		n := bufferSize(len(*vptr), nelems)
-		*vptr = make([]uint16, n)
+		n := min(len(*vptr), nelems)
+		if n == 0 {
+			n = nelems
+			*vptr = make([]uint16, n)
+		}
 		var buf [2]byte
 		for i := 0; i < n; i++ {
 			_, err := r.r.Read(buf[:])
@@ -453,8 +474,11 @@ func (r *Reader) Read(ptr interface{}) error {
 		if dt.rt != uint32Type {
 			return ErrTypeMismatch
 		}
-		n := bufferSize(len(*vptr), nelems)
-		*vptr = make([]uint32, n)
+		n := min(len(*vptr), nelems)
+		if n == 0 {
+			n = nelems
+			*vptr = make([]uint32, n)
+		}
 		var buf [4]byte
 		for i := 0; i < n; i++ {
 			_, err := r.r.Read(buf[:])
@@ -483,8 +507,11 @@ func (r *Reader) Read(ptr interface{}) error {
 		if dt.rt != uint64Type {
 			return ErrTypeMismatch
 		}
-		n := bufferSize(len(*vptr), nelems)
-		*vptr = make([]uint64, n)
+		n := min(len(*vptr), nelems)
+		if n == 0 {
+			n = nelems
+			*vptr = make([]uint64, n)
+		}
 		var buf [8]byte
 		for i := 0; i < n; i++ {
 			_, err := r.r.Read(buf[:])
@@ -513,8 +540,11 @@ func (r *Reader) Read(ptr interface{}) error {
 		if dt.rt != float32Type {
 			return ErrTypeMismatch
 		}
-		n := bufferSize(len(*vptr), nelems)
-		*vptr = make([]float32, n)
+		n := min(len(*vptr), nelems)
+		if n == 0 {
+			n = nelems
+			*vptr = make([]float32, n)
+		}
 		var buf [4]byte
 		for i := 0; i < n; i++ {
 			_, err := r.r.Read(buf[:])
@@ -543,8 +573,11 @@ func (r *Reader) Read(ptr interface{}) error {
 		if dt.rt != float64Type {
 			return ErrTypeMismatch
 		}
-		n := bufferSize(len(*vptr), nelems)
-		*vptr = make([]float64, n)
+		n := min(len(*vptr), nelems)
+		if n == 0 {
+			n = nelems
+			*vptr = make([]float64, n)
+		}
 		var buf [8]byte
 		for i := 0; i < n; i++ {
 			_, err := r.r.Read(buf[:])
@@ -575,8 +608,11 @@ func (r *Reader) Read(ptr interface{}) error {
 		if dt.rt != complex64Type {
 			return ErrTypeMismatch
 		}
-		n := bufferSize(len(*vptr), nelems)
-		*vptr = make([]complex64, n)
+		n := min(len(*vptr), nelems)
+		if n == 0 {
+			n = nelems
+			*vptr = make([]complex64, n)
+		}
 		var buf [8]byte
 		for i := 0; i < n; i++ {
 			_, err := r.r.Read(buf[:])
@@ -609,8 +645,11 @@ func (r *Reader) Read(ptr interface{}) error {
 		if dt.rt != complex128Type {
 			return ErrTypeMismatch
 		}
-		n := bufferSize(len(*vptr), nelems)
-		*vptr = make([]complex128, n)
+		n := min(len(*vptr), nelems)
+		if n == 0 {
+			n = nelems
+			*vptr = make([]complex128, n)
+		}
 		var buf [16]byte
 		for i := 0; i < n; i++ {
 			_, err := r.r.Read(buf[:])
@@ -824,14 +863,4 @@ func min(a, b int) int {
 		return a
 	}
 	return b
-}
-
-func bufferSize(l, m int) int {
-	var n int
-	if l != 0 {
-		n = min(l, m)
-	} else {
-		n = m
-	}
-	return n
 }

--- a/reader_test.go
+++ b/reader_test.go
@@ -186,7 +186,7 @@ func TestReaderSlice(t *testing.T) {
 					if err != nil {
 						t.Errorf("%v: error: %v\n", fname, err)
 					}
-					if pwant := reflect.ValueOf(wslice).Slice(0, 3); !sliceDeepEqual(pslice, pwant) {
+					if pwant := reflect.ValueOf(wslice).Slice(0, 3); !reflect.DeepEqual(pslice.Interface(), pwant.Interface()) {
 						t.Errorf("%v: error.\n got=%v\nwant=%v\n",
 							fname,
 							pslice,
@@ -414,18 +414,4 @@ func TestStringLenDtype(t *testing.T) {
 			continue
 		}
 	}
-}
-
-func sliceDeepEqual(r, s reflect.Value) bool {
-	if (r.Type() != s.Type()) || (r.Kind() != s.Kind()) || (r.Len() != s.Len()) {
-		return false
-	}
-	n := r.Len()
-	for i := 0; i < n; i++ {
-		u, v := r.Index(i), s.Index(i)
-		if (u.Kind() != v.Kind()) || (u.Type() != v.Type()) || (u.String() != v.String()) {
-			return false
-		}
-	}
-	return true
 }


### PR DESCRIPTION
When dealing with large `.npy` files, pulling all data to memory is not always feasible. This PR allows npyio to read chunks of data at a time by giving to the `Read` function an `n` sized slice instead of just a pointer. `Read` will then only read `n` items from file.